### PR TITLE
Updates browserlist by pumping safari to 16.4 due to required SIMD bu…

### DIFF
--- a/packages/blinkcard-core/README.md
+++ b/packages/blinkcard-core/README.md
@@ -17,8 +17,8 @@ This package supports image processing in these browser versions and newer:
 - Edge 96
 - Opera 84
 - Firefox 114 (desktop and Android)
-- Safari 15.1 (macOS)
-- iOS Safari 15.1
+- Safari 16.4 (macOS)
+- iOS Safari 16.4
 
 These minimums come from the combination of Emscripten-generated WebAssembly,
 required baseline Wasm features, and the module Web Worker used by

--- a/packages/blinkcard-core/package.json
+++ b/packages/blinkcard-core/package.json
@@ -102,7 +102,7 @@
     "Opera >= 84",
     "Firefox >= 114",
     "FirefoxAndroid >= 114",
-    "Safari >= 15.1",
-    "iOS >= 15.1"
+    "Safari >= 16.4",
+    "iOS >= 16.4"
   ]
 }

--- a/packages/blinkcard-worker/README.md
+++ b/packages/blinkcard-worker/README.md
@@ -16,8 +16,8 @@ This package supports image processing in these browser versions and newer:
 - Edge 96
 - Opera 84
 - Firefox 114 (desktop and Android)
-- Safari 15.1 (macOS)
-- iOS Safari 15.1
+- Safari 16.4 (macOS)
+- iOS Safari 16.4
 
 These minimums come from the combination of Emscripten-generated WebAssembly,
 required baseline Wasm features, and the module Web Worker used by

--- a/packages/blinkcard-worker/package.json
+++ b/packages/blinkcard-worker/package.json
@@ -66,7 +66,7 @@
     "Opera >= 84",
     "Firefox >= 114",
     "FirefoxAndroid >= 114",
-    "Safari >= 15.1",
-    "iOS >= 15.1"
+    "Safari >= 16.4",
+    "iOS >= 16.4"
   ]
 }

--- a/packages/blinkid-core/README.md
+++ b/packages/blinkid-core/README.md
@@ -17,8 +17,8 @@ This package supports image processing in these browser versions and newer:
 - Edge 96
 - Opera 84
 - Firefox 114 (desktop and Android)
-- Safari 15.1 (macOS)
-- iOS Safari 15.1
+- Safari 16.4 (macOS)
+- iOS Safari 16.4
 
 These minimums come from the combination of Emscripten-generated WebAssembly,
 required baseline Wasm features, and the module Web Worker used by

--- a/packages/blinkid-core/package.json
+++ b/packages/blinkid-core/package.json
@@ -111,7 +111,7 @@
     "Opera >= 84",
     "Firefox >= 114",
     "FirefoxAndroid >= 114",
-    "Safari >= 15.1",
-    "iOS >= 15.1"
+    "Safari >= 16.4",
+    "iOS >= 16.4"
   ]
 }

--- a/packages/blinkid-verify-core/README.md
+++ b/packages/blinkid-verify-core/README.md
@@ -17,8 +17,8 @@ This package supports image processing in these browser versions and newer:
 - Edge 96
 - Opera 84
 - Firefox 114 (desktop and Android)
-- Safari 15.1 (macOS)
-- iOS Safari 15.1
+- Safari 16.4 (macOS)
+- iOS Safari 16.4
 
 These minimums come from the combination of Emscripten-generated WebAssembly,
 required baseline Wasm features, and the module Web Worker used by

--- a/packages/blinkid-verify-core/package.json
+++ b/packages/blinkid-verify-core/package.json
@@ -113,7 +113,7 @@
     "Opera >= 84",
     "Firefox >= 114",
     "FirefoxAndroid >= 114",
-    "Safari >= 15.1",
-    "iOS >= 15.1"
+    "Safari >= 16.4",
+    "iOS >= 16.4"
   ]
 }

--- a/packages/blinkid-verify-worker/README.md
+++ b/packages/blinkid-verify-worker/README.md
@@ -16,8 +16,8 @@ This package supports image processing in these browser versions and newer:
 - Edge 96
 - Opera 84
 - Firefox 114 (desktop and Android)
-- Safari 15.1 (macOS)
-- iOS Safari 15.1
+- Safari 16.4 (macOS)
+- iOS Safari 16.4
 
 These minimums come from the combination of Emscripten-generated WebAssembly,
 required baseline Wasm features, and the module Web Worker used by

--- a/packages/blinkid-verify-worker/package.json
+++ b/packages/blinkid-verify-worker/package.json
@@ -63,7 +63,7 @@
     "Opera >= 84",
     "Firefox >= 114",
     "FirefoxAndroid >= 114",
-    "Safari >= 15.1",
-    "iOS >= 15.1"
+    "Safari >= 16.4",
+    "iOS >= 16.4"
   ]
 }

--- a/packages/blinkid-worker/README.md
+++ b/packages/blinkid-worker/README.md
@@ -16,8 +16,8 @@ This package supports image processing in these browser versions and newer:
 - Edge 96
 - Opera 84
 - Firefox 114 (desktop and Android)
-- Safari 15.1 (macOS)
-- iOS Safari 15.1
+- Safari 16.4 (macOS)
+- iOS Safari 16.4
 
 These minimums come from the combination of Emscripten-generated WebAssembly,
 required baseline Wasm features, and the module Web Worker used by

--- a/packages/blinkid-worker/package.json
+++ b/packages/blinkid-worker/package.json
@@ -64,7 +64,7 @@
     "Opera >= 84",
     "Firefox >= 114",
     "FirefoxAndroid >= 114",
-    "Safari >= 15.1",
-    "iOS >= 15.1"
+    "Safari >= 16.4",
+    "iOS >= 16.4"
   ]
 }


### PR DESCRIPTION
…ilds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated browser support guidance across BlinkCard and BlinkID packages.
  * Safari and iOS Safari minimum versions are now 16.4.

* **Compatibility**
  * Browser targeting now requires Safari 16.4 or later across supported packages.

* **Tests**
  * Updated browser support validation to reflect the new iOS Safari minimum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->